### PR TITLE
Add GitHub Actions workflow to deploy training platform to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Training Platform to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: training-platform/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: training-platform
+
+      - name: Build
+        run: npm run build
+        working-directory: training-platform
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: training-platform/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Builds the Vite React app from training-platform/ and deploys it using the actions/deploy-pages action. The vite base path is already configured for /database-chas/.

Note: After merging, go to repo Settings > Pages and set Source to "GitHub Actions" instead of "Deploy from a branch".
